### PR TITLE
Update ovpn_init.sh run failure

### DIFF
--- a/openvpn/bin/ovpn_init.sh
+++ b/openvpn/bin/ovpn_init.sh
@@ -63,7 +63,7 @@ EOF
   # generate static key for tls-auth
   run_or_exit "openvpn --genkey --secret $EASYRSA_PKI/ta.key"
   echo "INFO: Generating DH parameters, this might take a little"
-  res=$(time ${EASYRSA}/easyrsa --batch gen-dh 2>&1)
+  run_or_exit "${EASYRSA}/easyrsa --batch gen-dh 2>&1"
 }
 
 function write_server_config {


### PR DESCRIPTION
During "docker run -ti --rm --volumes-from=ovpn_data vpnbox_openvpn --init=udp://vpn.my-server.com:5443" it fails to produce DH key the correction resolves this.